### PR TITLE
Updated readme about the file read pointer update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,7 @@ Glacier.
 ### Library:
     Treehash::calculate_tree_hash string_or_io
 
+Do note that when a file object is passed, the read pointer is moved to the end of the file.
+
 ### Command-Line:
     $ treehash filename


### PR DESCRIPTION
After calculate_tree_hash, I was passing the file pointer to upload_archive function of Aws::Glacier::Client. And the error getting thrown from Aws library was content checksum mismatch and it was not so obvious what has been going wrong. 

Thought this simple update in the Readme will prevent people like me wasting time in debugging such issues in the future. 
